### PR TITLE
added ORider Carpool Oracle name

### DIFF
--- a/src/helpers/names.json
+++ b/src/helpers/names.json
@@ -66,6 +66,12 @@
     }
   },
   {
+    "address": "6XASCIHYUPKM67AO4LBQFY6WO24OXN5B",
+    "profile": {
+      "oracle_name": "ORider Carpool Oracle"
+    }
+  },
+  {
     "address": "BVVJ2K7ENPZZ3VYZFWQWK7ISPCATFIW3",
     "profile": {
       "witness_name": "Anton Churyumov"


### PR DESCRIPTION
This change adds the ORider Carpool Oracle name that is used by the https://ordier.obyte.app website. This oracle posts statuses of completed rides to unlock smart contracts created to pay for the rides or refund passengers.